### PR TITLE
BuildVersionWithQuality should add back the separator (-).

### DIFF
--- a/src/FlubuCore/Tasks/Versioning/BuildVersion.cs
+++ b/src/FlubuCore/Tasks/Versioning/BuildVersion.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace FlubuCore.Tasks.Versioning
 {
@@ -12,7 +10,8 @@ namespace FlubuCore.Tasks.Versioning
 
         public string BuildVersionWithQuality(int versionFieldCount)
         {
-            return $"{Version.ToString(versionFieldCount)}{VersionQuality}";
+            string quality = !string.IsNullOrEmpty(VersionQuality) ? $"-{VersionQuality}" : null;
+            return $"{Version.ToString(versionFieldCount)}{quality}";
         }
     }
 }


### PR DESCRIPTION
 The separator gets removed when parsing build version in FetchBuildVersionFromFileTask. The BuildVersion.BuildVersionWithQuality Should add it back.