### PR TITLE
Resolving #299: obsolete warnings about IHostingEnvironment and IApplication…

### DIFF
--- a/src/FlubuCore.WebApi/Controllers/PackagesController.cs
+++ b/src/FlubuCore.WebApi/Controllers/PackagesController.cs
@@ -8,8 +8,12 @@ using FlubuCore.WebApi.Controllers.Exceptions;
 using FlubuCore.WebApi.Model;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+#if NETCOREAPP3_1
+  using Microsoft.Extensions.Hosting;
+#else
+  using IHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
+#endif
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json;
@@ -22,14 +26,12 @@ namespace FlubuCore.WebApi.Controllers
     public class PackagesController : ControllerBase
     {
         private readonly string[] _allowedFileExtension = { ".zip", ".7z", ".rar" };
-
-        private readonly IHostingEnvironment _hostingEnvironment;
-
+        private readonly IHostEnvironment _hostEnvironment;
         private readonly ILogger<PackagesController> _logger;
 
-        public PackagesController(IHostingEnvironment hostingEnvironment, ILogger<PackagesController> logger)
+        public PackagesController(IHostEnvironment hostEnvironment, ILogger<PackagesController> logger)
         {
-            _hostingEnvironment = hostingEnvironment;
+            _hostEnvironment = hostEnvironment;
             _logger = logger;
         }
 
@@ -97,7 +99,7 @@ namespace FlubuCore.WebApi.Controllers
         [HttpDelete]
         public IActionResult CleanPackagesDirectory([FromBody]CleanPackagesDirectoryRequest request)
         {
-            var uploadDirectory = Path.Combine(_hostingEnvironment.ContentRootPath, "Packages");
+            var uploadDirectory = Path.Combine(_hostEnvironment.ContentRootPath, "Packages");
 
             if (!string.IsNullOrWhiteSpace(request.SubDirectoryToDelete))
             {
@@ -131,7 +133,7 @@ namespace FlubuCore.WebApi.Controllers
         private string GetUploadDirectory()
         {
             var form = Request.Form;
-            var uploadDirectory = Path.Combine(_hostingEnvironment.ContentRootPath, "Packages");
+            var uploadDirectory = Path.Combine(_hostEnvironment.ContentRootPath, "Packages");
             if (form.ContainsKey("request"))
             {
                 StringValues request = form["request"];

--- a/src/FlubuCore.WebApi/Controllers/ReportsController.cs
+++ b/src/FlubuCore.WebApi/Controllers/ReportsController.cs
@@ -12,8 +12,12 @@ using FlubuCore.WebApi.Controllers.Exceptions;
 using FlubuCore.WebApi.Model;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+#if NETCOREAPP3_1
+    using Microsoft.Extensions.Hosting;
+#else
+using IHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
+#endif
 
 namespace FlubuCore.WebApi.Controllers
 {
@@ -21,15 +25,15 @@ namespace FlubuCore.WebApi.Controllers
     [Route("api/[controller]")]
     public class ReportsController : ControllerBase
     {
-        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly IHostEnvironment _hostEnvironment;
 
         private readonly ITaskFactory _taskFactory;
 
         private readonly IFlubuSession _flubuSession;
 
-        public ReportsController(IHostingEnvironment hostingEnvironment, ITaskFactory taskFactory, IFlubuSession flubuSession)
+        public ReportsController(IHostEnvironment hostEnvironment, ITaskFactory taskFactory, IFlubuSession flubuSession)
         {
-            _hostingEnvironment = hostingEnvironment;
+            _hostEnvironment = hostEnvironment;
             _taskFactory = taskFactory;
             _flubuSession = flubuSession;
         }
@@ -42,7 +46,7 @@ namespace FlubuCore.WebApi.Controllers
         [HttpPost("download")]
         public IActionResult DownloadReports([FromBody]DownloadReportsRequest request)
         {
-            string downloadDirectory = Path.Combine(_hostingEnvironment.ContentRootPath, "Reports");
+            string downloadDirectory = Path.Combine(_hostEnvironment.ContentRootPath, "Reports");
 
             if (!Directory.Exists(downloadDirectory))
             {
@@ -92,7 +96,7 @@ namespace FlubuCore.WebApi.Controllers
         [HttpDelete("download")]
         public IActionResult CleanPackagesDirectory([FromBody]CleanPackagesDirectoryRequest request)
         {
-            var downloadDirectory = Path.Combine(_hostingEnvironment.ContentRootPath, "Reports");
+            var downloadDirectory = Path.Combine(_hostEnvironment.ContentRootPath, "Reports");
 
             if (!string.IsNullOrWhiteSpace(request.SubDirectoryToDelete))
             {

--- a/src/FlubuCore.WebApi/Controllers/ScriptsController.cs
+++ b/src/FlubuCore.WebApi/Controllers/ScriptsController.cs
@@ -16,8 +16,12 @@ using FlubuCore.WebApi.Repository;
 using LiteDB;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+#if NETCOREAPP3_1
+    using Microsoft.Extensions.Hosting;
+#else
+    using IHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
+#endif
 using Microsoft.Build.Framework;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -38,7 +42,7 @@ namespace FlubuCore.WebApi.Controllers
 
         private readonly CommandArguments _commandArguments;
 
-        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly IHostEnvironment _hostEnvironment;
 
         private readonly WebApiSettings _webApiSettings;
 
@@ -46,14 +50,14 @@ namespace FlubuCore.WebApi.Controllers
             IRepositoryFactory repositoryFactory,
             ICommandExecutor commandExecutor,
             CommandArguments commandArguments,
-            IHostingEnvironment hostingEnvironment,
+            IHostEnvironment hostingEnvironment,
             IOptions<WebApiSettings> webApiOptions,
             ILogger<ScriptsController> logger)
         {
             _repositoryFactory = repositoryFactory;
             _commandExecutor = commandExecutor;
             _commandArguments = commandArguments;
-            _hostingEnvironment = hostingEnvironment;
+            _hostEnvironment = hostingEnvironment;
             _logger = logger;
             _webApiSettings = webApiOptions.Value;
         }
@@ -126,7 +130,7 @@ namespace FlubuCore.WebApi.Controllers
                 throw new HttpError(HttpStatusCode.BadRequest, "NoFiles");
             }
 
-            var uploads = Path.Combine(_hostingEnvironment.ContentRootPath, "Scripts");
+            var uploads = Path.Combine(_hostEnvironment.ContentRootPath, "Scripts");
 
             var script = form.Files[0];
 
@@ -162,7 +166,7 @@ namespace FlubuCore.WebApi.Controllers
         private void PrepareCommandArguments(ExecuteScriptRequest request)
         {
             _commandArguments.MainCommands = new List<string>();
-            var scriptFullPath = Path.Combine(_hostingEnvironment.ContentRootPath, "Scripts", request.ScriptFileName);
+            var scriptFullPath = Path.Combine(_hostEnvironment.ContentRootPath, "Scripts", request.ScriptFileName);
             _commandArguments.MainCommands.Add(request.TargetToExecute);
             _commandArguments.Script = scriptFullPath;
             _commandArguments.IsWebApi = true;

--- a/src/FlubuCore.WebApi/Controllers/WebApp/ScriptController.cs
+++ b/src/FlubuCore.WebApi/Controllers/WebApp/ScriptController.cs
@@ -11,10 +11,14 @@ using FlubuCore.WebApi.Models;
 using FlubuCore.WebApi.Models.ViewModels;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.Options;
+#if NETCOREAPP3_1
+    using Microsoft.Extensions.Hosting;
+#else
+    using IHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
+#endif
 
 namespace FlubuCore.WebApi.Controllers.WebApp
 {
@@ -26,7 +30,7 @@ namespace FlubuCore.WebApi.Controllers.WebApp
 #endif
     public class ScriptController : Controller
     {
-        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly IHostEnvironment _hostEnvironment;
 
         private readonly ITargetExtractor _targetExtractor;
 
@@ -37,13 +41,13 @@ namespace FlubuCore.WebApi.Controllers.WebApp
             ;
 
         public ScriptController(
-            IHostingEnvironment hostingEnvironment,
+            IHostEnvironment hostEnvironment,
             ITargetExtractor targetExtractor,
             ICommandExecutor commandExecutor,
             CommandArguments commandArguments,
             IOptions<WebAppSettings> webApiOptions)
         {
-            _hostingEnvironment = hostingEnvironment;
+            _hostEnvironment = hostEnvironment;
             _targetExtractor = targetExtractor;
             _commandExecutor = commandExecutor;
             _commandArguments = commandArguments;
@@ -58,7 +62,7 @@ namespace FlubuCore.WebApi.Controllers.WebApp
                 return NotFound();
             }
 
-            var scriptsFullPath = Path.Combine(_hostingEnvironment.ContentRootPath, "Scripts");
+            var scriptsFullPath = Path.Combine(_hostEnvironment.ContentRootPath, "Scripts");
 
             if (!Directory.Exists(scriptsFullPath))
             {
@@ -86,7 +90,7 @@ namespace FlubuCore.WebApi.Controllers.WebApp
                 return NotFound();
             }
 
-            var scriptsFullPath = Path.Combine(_hostingEnvironment.ContentRootPath, "Scripts", scriptName);
+            var scriptsFullPath = Path.Combine(_hostEnvironment.ContentRootPath, "Scripts", scriptName);
             var targets = _targetExtractor.ExtractTargets(scriptsFullPath);
             return Ok(targets);
         }
@@ -127,7 +131,7 @@ namespace FlubuCore.WebApi.Controllers.WebApp
         private void PrepareCommandArguments(string scriptName, string targetName)
         {
             _commandArguments.MainCommands = new List<string>();
-            var scriptFullPath = Path.Combine(_hostingEnvironment.ContentRootPath, "Scripts", scriptName);
+            var scriptFullPath = Path.Combine(_hostEnvironment.ContentRootPath, "Scripts", scriptName);
             _commandArguments.MainCommands.Add(targetName);
             _commandArguments.Script = scriptFullPath;
             _commandArguments.RethrowOnException = true;

--- a/src/FlubuCore.WebApi/Controllers/WebApp/UpdateCenterController.cs
+++ b/src/FlubuCore.WebApi/Controllers/WebApp/UpdateCenterController.cs
@@ -15,9 +15,13 @@ using FlubuCore.Tasks.Text;
 using FlubuCore.WebApi.Models.ViewModels;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+#if NETCOREAPP3_1
+    using Microsoft.Extensions.Hosting;
+#else
+    using IHostApplicationLifetime = Microsoft.AspNetCore.Hosting.IApplicationLifetime;
+    using IHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
+#endif
 using Octokit;
 
 namespace FlubuCore.WebApi.Controllers.WebApp
@@ -41,16 +45,16 @@ namespace FlubuCore.WebApi.Controllers.WebApp
 
         private readonly IFlubuSession _flubuSession;
 
-        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly IHostEnvironment _hostEnvironment;
 
-        private readonly IApplicationLifetime _applicationLifetime;
+        private readonly IHostApplicationLifetime _applicationLifetime;
 
-        public UpdateCenterController(IGitHubClient client, ITaskFactory taskFactory, IFlubuSession flubuSession, IHostingEnvironment hostingEnvironment, IApplicationLifetime applicationLifetime)
+        public UpdateCenterController(IGitHubClient client, ITaskFactory taskFactory, IFlubuSession flubuSession, IHostEnvironment hostEnvironment, IHostApplicationLifetime applicationLifetime)
         {
             _client = client;
             _taskFactory = taskFactory;
             _flubuSession = flubuSession;
-            _hostingEnvironment = hostingEnvironment;
+            _hostEnvironment = hostEnvironment;
             _applicationLifetime = applicationLifetime;
         }
 
@@ -138,7 +142,7 @@ namespace FlubuCore.WebApi.Controllers.WebApp
                 }
             }
 
-            var rootDir = _hostingEnvironment.ContentRootPath;
+            var rootDir = _hostEnvironment.ContentRootPath;
             if (!Directory.Exists(Path.Combine(rootDir, "Updates")))
             {
                 Directory.CreateDirectory(Path.Combine(rootDir, "Updates"));
@@ -169,7 +173,7 @@ namespace FlubuCore.WebApi.Controllers.WebApp
         public IActionResult Restart()
         {
             var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            var rootDir = _hostingEnvironment.ContentRootPath;
+            var rootDir = _hostEnvironment.ContentRootPath;
             Process.Start(new ProcessStartInfo
             {
                 WorkingDirectory = Path.GetDirectoryName(Path.Combine(rootDir, "Updates/WebApi")),

--- a/src/FlubuCore.WebApi/FlubuCore.WebApi.csproj
+++ b/src/FlubuCore.WebApi/FlubuCore.WebApi.csproj
@@ -97,32 +97,20 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions">
-      <Version>2.1.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies">
-      <Version>2.1.1</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles">
-      <Version>2.1.1</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
   </ItemGroup>
   
     <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
       <PackageReference Include="Microsoft.AspNetCore" Version="2.1.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions">
-      <Version>2.1.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies">
-      <Version>2.1.1</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles">
-      <Version>2.1.1</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
    </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
@@ -131,17 +119,11 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions">
-      <Version>2.1.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies">
-      <Version>2.1.1</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles">
-      <Version>2.1.1</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.1" />

--- a/src/FlubuCore.WebApi/Startup.cs
+++ b/src/FlubuCore.WebApi/Startup.cs
@@ -7,7 +7,11 @@ using FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
+#if NETCOREAPP3_1
+    using Microsoft.Extensions.Hosting;
+#else
+using IHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
+#endif
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Configuration;
@@ -26,7 +30,7 @@ namespace FlubuCore.WebApi
 
         private SymmetricSecurityKey _signingKey;
 
-        public Startup(IHostingEnvironment env)
+        public Startup(IHostEnvironment env)
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
@@ -69,7 +73,7 @@ namespace FlubuCore.WebApi
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app, IHostEnvironment env, ILoggerFactory loggerFactory)
         {
             Logger log = new LoggerConfiguration()
                 .WriteTo.LiteDB($"Logs/log_{DateTime.Now.Date:yyyy-dd-M}.db")


### PR DESCRIPTION
I know this issue is targeting milestone 6.0. 
However, I try to make the changes to support ASP.NET Core 2.x, 3.x, and ASP.NET 4.6.
One reason being that, even in FlubuCore v6, we might still need to support ASP.NET Core 2.x.
So I think maybe it can be merged to develop branch? Not sure though.
Please help me make the decision. If these changes should still go to milestone 6, I'll close this PR and create a new one targeting v6.