### PR TITLE
Resolving #302: DependsOnAsync tasks always show "Not Ran" 

### DIFF
--- a/src/FlubuCore/Tasks/TaskBase.cs
+++ b/src/FlubuCore/Tasks/TaskBase.cs
@@ -435,7 +435,9 @@ namespace FlubuCore.Tasks
 
                 InvokeForMembers(_forMembers, contextInternal.Args.DisableInteractive);
 
-                return await DoExecuteAsync(contextInternal);
+                var result = await DoExecuteAsync(contextInternal);
+                TaskStatus = TaskStatus.Finished;
+                return result;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
While fixing this bug, one idea popped up:

The tasks configured with `DependsOnAsync` method are actually executed with `Task.Run`, which is arguably not asynchronous calls. I mean the following code in TaskBase.cs:

```
protected virtual async Task<TResult> DoExecuteAsync(ITaskContextInternal context)
{
    return await Task.Run(() => DoExecute(context));
}
```

Having said that, I don't have better ideas to run those "Async" tasks simply because we don't know what those user-defined tasks really do (could be CPU-bound or I/O bound).

I'm just feel that `DependsOnAsync` might mislead people, make them think that those tasks are executed with C# asynchronous calls.
 
So one possible change is to rename `DependsOnAsync` to something else, maybe `DependsOnParallel` or `DependsOnConcurrently` ?

I may be wrong or missed something though. So this is just a note. No further action requested. (discussions are welcomed) 