### PR TITLE
Resolving FileStream.Lock issue on OSX

### DIFF
--- a/src/Build.csproj
+++ b/src/Build.csproj
@@ -135,7 +135,7 @@
     <DotNetCliToolReference Include="dotnet-flubu" Version="5.1.8" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="LiteDB" Version="4.1.2" />
+    <PackageReference Include="LiteDB" Version="5.0.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="FlubuCore.WebApi\FlubuCore.WebApi.csproj" />

--- a/src/Deploy/Deploy.csproj
+++ b/src/Deploy/Deploy.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
   
-    <PackageReference Include="LiteDB" Version="4.1.2" />
+    <PackageReference Include="LiteDB" Version="5.0.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FlubuCore.WebApi\FlubuCore.WebApi.csproj" />

--- a/src/Deploy/DeployScript.cs
+++ b/src/Deploy/DeployScript.cs
@@ -54,7 +54,7 @@ namespace DeploymentScript
             else
             {
                 var liteDbPassword = GenerateRandomSecureString(15);
-                connectionString = $"FileName=database.db;Mode=Shared; Password={liteDbPassword}";
+                connectionString = $"FileName=database.db;Upgrade=true;Connection=Shared; Password={liteDbPassword}";
             }
 
             bool createDb = false;

--- a/src/Deploy/DeployScript.cs
+++ b/src/Deploy/DeployScript.cs
@@ -54,7 +54,7 @@ namespace DeploymentScript
             else
             {
                 var liteDbPassword = GenerateRandomSecureString(15);
-                connectionString = $"FileName=database.db; Password={liteDbPassword}";
+                connectionString = $"FileName=database.db;Mode=Shared; Password={liteDbPassword}";
             }
 
             bool createDb = false;

--- a/src/Deploy/DeploymentScript.cs
+++ b/src/Deploy/DeploymentScript.cs
@@ -51,7 +51,7 @@ namespace DeploymentScript
             else
             {
                 var liteDbPassword = GenerateRandomSecureString(15);
-                connectionString = $"FileName=database.db; Password={liteDbPassword}";
+                connectionString = $"FileName=database.db;Mode=Shared; Password={liteDbPassword}";
             }
 
             bool createDb = false;

--- a/src/Deploy/DeploymentScript.cs
+++ b/src/Deploy/DeploymentScript.cs
@@ -51,7 +51,7 @@ namespace DeploymentScript
             else
             {
                 var liteDbPassword = GenerateRandomSecureString(15);
-                connectionString = $"FileName=database.db;Mode=Shared; Password={liteDbPassword}";
+                connectionString = $"FileName=database.db;Upgrade=true;Connection=Shared; Password={liteDbPassword}";
             }
 
             bool createDb = false;

--- a/src/FlubuCore.Tests/FlubuCore.Tests.csproj
+++ b/src/FlubuCore.Tests/FlubuCore.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <WarningsAsErrors>true</WarningsAsErrors>
@@ -69,7 +69,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.3" />
-    <PackageReference Include="moq" Version="4.14.0" />
+    <PackageReference Include="moq" Version="4.14.1" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/src/FlubuCore.WebApi.Tests/ClientTests/ClientFixture.cs
+++ b/src/FlubuCore.WebApi.Tests/ClientTests/ClientFixture.cs
@@ -20,7 +20,7 @@ namespace FlubuCore.WebApi.Tests.ClientTests
         public ClientFixture()
         {
             _hashService = new HashService();
-            LiteRepository = new LiteRepository("Filename=database.db");
+            LiteRepository = new LiteRepository("Filename=database.db;Mode=Shared");
             _repository = new UserRepository(LiteRepository);
             var hashedPassword = _hashService.Hash("password");
             LiteRepository.Database.DropCollection("users");

--- a/src/FlubuCore.WebApi.Tests/ClientTests/ClientFixture.cs
+++ b/src/FlubuCore.WebApi.Tests/ClientTests/ClientFixture.cs
@@ -20,7 +20,7 @@ namespace FlubuCore.WebApi.Tests.ClientTests
         public ClientFixture()
         {
             _hashService = new HashService();
-            LiteRepository = new LiteRepository("Filename=database.db;Mode=Shared");
+            LiteRepository = new LiteRepository("Filename=database.db;Upgrade=true;Connection=Shared");
             _repository = new UserRepository(LiteRepository);
             var hashedPassword = _hashService.Hash("password");
             LiteRepository.Database.DropCollection("users");

--- a/src/FlubuCore.WebApi.Tests/DatabaseBaseTests.cs
+++ b/src/FlubuCore.WebApi.Tests/DatabaseBaseTests.cs
@@ -10,7 +10,7 @@ namespace FlubuCore.WebApi.Tests
     {
         public DatabaseBaseTests()
         {
-            LiteRepository = new LiteRepository("Filename=database.db");
+            LiteRepository = new LiteRepository("Filename=database.db;Mode=Shared");
             LiteRepository.Database.DropCollection("users");
         }
 

--- a/src/FlubuCore.WebApi.Tests/DatabaseBaseTests.cs
+++ b/src/FlubuCore.WebApi.Tests/DatabaseBaseTests.cs
@@ -10,7 +10,7 @@ namespace FlubuCore.WebApi.Tests
     {
         public DatabaseBaseTests()
         {
-            LiteRepository = new LiteRepository("Filename=database.db;Mode=Shared");
+            LiteRepository = new LiteRepository("Filename=database.db;Upgrade=true;Connection=Shared");
             LiteRepository.Database.DropCollection("users");
         }
 

--- a/src/FlubuCore.WebApi.Tests/FlubuCore.WebApi.Tests.csproj
+++ b/src/FlubuCore.WebApi.Tests/FlubuCore.WebApi.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LiteDB" Version="4.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="LiteDB" Version="5.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/FlubuCore.WebApi/FlubuCore.WebApi.csproj
+++ b/src/FlubuCore.WebApi/FlubuCore.WebApi.csproj
@@ -81,6 +81,7 @@
     <PackageReference Include="LiteDB" Version="5.0.8" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.5.0" />
     <PackageReference Include="Octokit" Version="0.47.0" />
+    <PackageReference Include="Serilog.Sinks.LiteDB" Version="1.0.24" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -129,14 +130,6 @@
     <ProjectReference Include="..\FlubuCore.WebApi.Client\FlubuCore.WebApi.Client.csproj" />
     <ProjectReference Include="..\FlubuCore.WebApi.Model\FlubuCore.WebApi.Model.csproj" />
     <ProjectReference Include="..\FlubuCore\FlubuCore.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Serilog.Sinks.LiteDB">
-      <HintPath>..\packages\SerilogSinksLiTeDb\Serilog.Sinks.LiteDB.dll</HintPath>
-    </Reference>
-    <Reference Include="Serilog.Sinks.PeriodicBatching">
-      <HintPath>..\packages\SerilogSinksLiTeDb\Serilog.Sinks.PeriodicBatching.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ProjectExtensions><VisualStudio><UserProperties appsettings_1json__JsonSchema="" /></VisualStudio></ProjectExtensions>
 

--- a/src/FlubuCore.WebApi/FlubuCore.WebApi.csproj
+++ b/src/FlubuCore.WebApi/FlubuCore.WebApi.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;netcoreapp3.1;net462</TargetFrameworks>
@@ -78,7 +78,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
-    <PackageReference Include="LiteDB" Version="4.1.2" />
+    <PackageReference Include="LiteDB" Version="5.0.8" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.5.0" />
     <PackageReference Include="Octokit" Version="0.47.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
@@ -138,5 +138,6 @@
       <HintPath>..\packages\SerilogSinksLiTeDb\Serilog.Sinks.PeriodicBatching.dll</HintPath>
     </Reference>
   </ItemGroup>
+  <ProjectExtensions><VisualStudio><UserProperties appsettings_1json__JsonSchema="" /></VisualStudio></ProjectExtensions>
 
 </Project>

--- a/src/FlubuCore.WebApi/Repository/RepositoryFactory.cs
+++ b/src/FlubuCore.WebApi/Repository/RepositoryFactory.cs
@@ -20,7 +20,8 @@ namespace FlubuCore.WebApi.Repository
 
         public ISerilogRepository CreateSerilogRepository()
         {
-            return new SerilogRepository(_liteRepositoryFactory.CreateLiteDatabase($"Logs/log_{_timeProvider.Now.Date:yyyy-dd-M}.db"));
+            var connStr = $"FileName=Logs/log_{_timeProvider.Now.Date:yyyy-dd-M}.db;Upgrade=true;Connection=Shared";
+            return new SerilogRepository(_liteRepositoryFactory.CreateLiteDatabase(connStr));
         }
     }
 }

--- a/src/FlubuCore.WebApi/Repository/RepositoryFactory.cs
+++ b/src/FlubuCore.WebApi/Repository/RepositoryFactory.cs
@@ -20,8 +20,7 @@ namespace FlubuCore.WebApi.Repository
 
         public ISerilogRepository CreateSerilogRepository()
         {
-            //var connStr = $"FileName=Logs/log_{_timeProvider.Now.Date:yyyy-dd-M}.db;Upgrade=true;Connection=Shared";
-            var connStr = $"Logs/log_{_timeProvider.Now.Date:yyyy-dd-M}.db";
+            var connStr = $"FileName=Logs/log_{_timeProvider.Now.Date:yyyy-dd-M}.db;Upgrade=true;Connection=Shared";
             return new SerilogRepository(_liteRepositoryFactory.CreateLiteDatabase(connStr));
         }
     }

--- a/src/FlubuCore.WebApi/Repository/RepositoryFactory.cs
+++ b/src/FlubuCore.WebApi/Repository/RepositoryFactory.cs
@@ -20,7 +20,8 @@ namespace FlubuCore.WebApi.Repository
 
         public ISerilogRepository CreateSerilogRepository()
         {
-            var connStr = $"FileName=Logs/log_{_timeProvider.Now.Date:yyyy-dd-M}.db;Upgrade=true;Connection=Shared";
+            //var connStr = $"FileName=Logs/log_{_timeProvider.Now.Date:yyyy-dd-M}.db;Upgrade=true;Connection=Shared";
+            var connStr = $"Logs/log_{_timeProvider.Now.Date:yyyy-dd-M}.db";
             return new SerilogRepository(_liteRepositoryFactory.CreateLiteDatabase(connStr));
         }
     }

--- a/src/FlubuCore.WebApi/appsettings.json
+++ b/src/FlubuCore.WebApi/appsettings.json
@@ -28,7 +28,7 @@
 
   "FlubuConnectionStrings":
   {
-    "LiteDbConnectionString" : "Filename=database.db" ////Modified by deploy script when deploying.
+    "LiteDbConnectionString" : "Filename=database.db;Mode=Shared" ////Modified by deploy script when deploying.
   },
 
   "JwtOptions": {

--- a/src/FlubuCore.WebApi/appsettings.json
+++ b/src/FlubuCore.WebApi/appsettings.json
@@ -28,7 +28,7 @@
 
   "FlubuConnectionStrings":
   {
-    "LiteDbConnectionString" : "Filename=database.db;Mode=Shared" ////Modified by deploy script when deploying.
+    "LiteDbConnectionString" : "Filename=database.db;Upgrade=true;Connection=Shared" ////Modified by deploy script when deploying.
   },
 
   "JwtOptions": {


### PR DESCRIPTION
The issue seems resolved after LiteDB is updated from v4 to v5, and used up-to-date version of Serilog.Sinks.LiteDB package from nuget feed.