### PR TITLE
Show working folder with full path

### DIFF
--- a/src/FlubuCore.ConsoleTestApp/DefaultTestScript.cs
+++ b/src/FlubuCore.ConsoleTestApp/DefaultTestScript.cs
@@ -1,16 +1,22 @@
 ﻿using FlubuCore.Context;
 using FlubuCore.Context.Attributes;
+using FlubuCore.Context.Attributes.BuildProperties;
 using FlubuCore.Scripting;
 
 namespace FlubuCore.ConsoleTestApp
 {
     public class DefaultTestScript : DefaultBuildScript
-    {        
+    {
+        [SolutionFileName]
+        public string SolutionFileName => "flubu.sln";
+
         public string Output => RootDirectory.CombineWith("output222");
         
         protected override void ConfigureTargets(ITaskContext context)
         {
-            context.CreateTarget("Test").SetAsDefault().AddCoreTask(x => x.Build());
+            context.CreateTarget("Test")
+                .SetAsDefault()
+                .AddCoreTask(x => x.Restore().WorkingFolder("../../../.."));
         }
     }
 }

--- a/src/FlubuCore/Tasks/Process/RunProgramTask.cs
+++ b/src/FlubuCore/Tasks/Process/RunProgramTask.cs
@@ -99,7 +99,7 @@ namespace FlubuCore.Tasks.Process
             if (string.IsNullOrEmpty(folder) || folder.Equals(".", StringComparison.OrdinalIgnoreCase))
                 return this;
 
-            _workingFolder = Path.GetFullPath(folder);
+            _workingFolder = folder;
             return this;
         }
 
@@ -248,7 +248,7 @@ namespace FlubuCore.Tasks.Process
                 commandArgs = !arg.maskArg ? $"{commandArgs} {arg.arg}" : $"{commandArgs} ####";
             }
 
-            DoLogInfo($"Running program from '{workingFolder}':");
+            DoLogInfo($"Running program from '{Path.GetFullPath(workingFolder)}':");
             DoLogInfo($"{cmd}{commandArgs}{Environment.NewLine}", Color.DarkCyan);
 
             int res = command.Execute()

--- a/src/FlubuCore/Tasks/Process/RunProgramTask.cs
+++ b/src/FlubuCore/Tasks/Process/RunProgramTask.cs
@@ -99,7 +99,7 @@ namespace FlubuCore.Tasks.Process
             if (string.IsNullOrEmpty(folder) || folder.Equals(".", StringComparison.OrdinalIgnoreCase))
                 return this;
 
-            _workingFolder = folder;
+            _workingFolder = Path.GetFullPath(folder);
             return this;
         }
 


### PR DESCRIPTION
Example in DefaultTestScript.cs:
```
    protected override void ConfigureTargets(ITaskContext context)
    {
        context.CreateTarget("Test")
            .SetAsDefault()
            .AddCoreTask(x => x.Restore().WorkingFolder("../../../.."));
    }
```
Output:
```
Executing target Test
Executing task DotnetRestoreTask
   Running program from 'D:\Work\GitHub\FlubuCore\src':
   C:\Program Files\dotnet\dotnet.exe restore flubu.sln
```