### PR TITLE
Fixes git clone syntax

### DIFF
--- a/src/FlubuCore/Tasks/Git/GitCloneTask.cs
+++ b/src/FlubuCore/Tasks/Git/GitCloneTask.cs
@@ -119,7 +119,7 @@ namespace FlubuCore.Tasks.Git
         protected override int DoExecute(ITaskContextInternal context)
         {
             _repository.MustNotBeNullOrEmpty("Url of the repository to clone must not be empty.");
-            WithArguments(_directory, _repository);
+            WithArguments(_repository, _directory);
             return base.DoExecute(context);
         }
     }


### PR DESCRIPTION
### Current Behavior
`git clone [<options>] [--] <dir> <repo>`

### Correct Behavior
`git clone [<options>] [--] <repo> [<dir>]`

`<dir>` argument must be the latest one